### PR TITLE
remove save method call since it isn't declared

### DIFF
--- a/src/app/course-dialog/course-dialog.component.html
+++ b/src/app/course-dialog/course-dialog.component.html
@@ -61,10 +61,8 @@
         Close
     </button>
 
-    <button mat-raised-button color="primary" #saveButton (click)="save()">
+    <button mat-raised-button color="primary" #saveButton>
         Save
     </button>
 
 </mat-dialog-actions>
-
-


### PR DESCRIPTION
In the 4th lecture - [Environment setup - Get the Lessons Code Up and Running](https://www.udemy.com/course/rxjs-course/learn/lecture/10785282)

From a transcript
```
This branch here, when dash operators contains the code that we will need in the beginning of the course.
```

After ```npm i``` and ```npm start``` an initial branch  has the following error. 

```
  ~/Programming/rxjs-course on   1-operators                                                                                                          took  9s  system at  13:47:05
❯ npm start

> rxjs-course@0.0.0 start
> ng serve  --proxy-config ./proxy.json

One or more browsers which are configured in the project's Browserslist configuration will be ignored as ES5 output is not supported by the Angular CLI.
Ignored browsers: kaios 2.5, op_mini all
✔ Browser application bundle generation complete.

Initial Chunk Files   | Names         |  Raw Size
vendor.js             | vendor        |   5.85 MB |
styles.css, styles.js | styles        | 350.22 kB |
polyfills.js          | polyfills     | 316.85 kB |
main.js               | main          |  58.20 kB |
runtime.js            | runtime       |   8.35 kB |

                      | Initial Total |   6.56 MB

Build at: 2023-04-20T10:47:22.730Z - Hash: 3f55abb3f5deee9c - Time: 10139ms

Warning: ~/Programming/rxjs-course/src/app/course-dialog/course-dialog.component.ts depends on 'moment'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies



Error: src/app/course-dialog/course-dialog.component.html:64:68 - error TS2339: Property 'save' does not exist on type 'CourseDialogComponent'.

64     <button mat-raised-button color="primary" #saveButton (click)="save()">
                                                                      ~~~~

  src/app/course-dialog/course-dialog.component.ts:12:18
    12     templateUrl: './course-dialog.component.html',
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Error occurs in the template of component CourseDialogComponent.




** Angular Live Development Server is listening on localhost:4200, open your browser on http://localhost:4200/ **
```

Since this method isn't used in the first section of the course I just removed it.

Not related, but similar issue https://github.com/angular-university/rxjs-course/issues/7