### PR TITLE
Missing save() function for initial run shown in video

### DIFF
--- a/src/app/course-dialog/course-dialog.component.ts
+++ b/src/app/course-dialog/course-dialog.component.ts
@@ -56,6 +56,8 @@ export class CourseDialogComponent implements OnInit, AfterViewInit {
         this.dialogRef.close();
     }
 
+
+
     save() {
 
 

--- a/src/app/course-dialog/course-dialog.component.ts
+++ b/src/app/course-dialog/course-dialog.component.ts
@@ -56,4 +56,9 @@ export class CourseDialogComponent implements OnInit, AfterViewInit {
         this.dialogRef.close();
     }
 
+    save() {
+
+
+    }
+
 }


### PR DESCRIPTION
Fix:
For course: RxJS in Practice, video: Environment Setup - Get the Lessons Code Up and Running. @6:02 Vasco asks us to execute `npm start`. Command gives error due to no save() function stub being present initially. Adding stub.